### PR TITLE
Remove unwrap that causes panic!

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ fn parse_as_toml(config: String) -> Config {
 
 pub fn open_config() -> Result<Config, std::io::Error> {
     let conf_path = config_path();
-    let mut config_file: File = File::open(&conf_path).unwrap();
+    let mut config_file: File = File::open(&conf_path)?;
     let config_string = read_as_string(&mut config_file);
     let config_toml = parse_as_toml(config_string);
 


### PR DESCRIPTION
For some reason this got added. Running ACS without a config file will cause a crash before this change.
