### PR TITLE
Cpu percent

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,11 +217,20 @@ fn parse_args(config: config::Config) {
                 Err(_) => eprintln!("Failed to get read lid state"),
             },
 
-            GetType::Usage { raw } => match get_cpu_percent() {
-                Ok(content) => {
-                    println!("{}", content)
+            GetType::Usage { raw } => {
+                if !raw {
+                    println!("Calculating cpu percentage over 1 second.");
                 }
-                Err(_) => println!("Unable to usage status"),
+                match get_cpu_percent() {
+                    Ok(content) => {
+                        if raw {
+                            println!("{}", content)
+                        } else {
+                            println!("CPU is at {}%", content)
+                        }
+                    }
+                    Err(_) => println!("Unable to usage status"),
+                }
             },
 
             GetType::Turbo { raw } => match check_turbo_enabled() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,7 +231,7 @@ fn parse_args(config: config::Config) {
                     }
                     Err(_) => println!("Unable to usage status"),
                 }
-            },
+            }
 
             GetType::Turbo { raw } => match check_turbo_enabled() {
                 Ok(turbo_enabled) => print_turbo(turbo_enabled, raw),

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use power::{read_battery_charge, read_lid_state, read_power_source};
 use settings::Settings;
 use system::{
     check_available_governors, check_cpu_freq, check_cpu_name, check_turbo_enabled,
-    list_cpu_governors, list_cpu_speeds, list_cpu_temp, list_cpus,
+    list_cpu_governors, list_cpu_speeds, list_cpu_temp, list_cpus, get_cpu_percent,
 };
 
 pub mod config;
@@ -33,6 +33,13 @@ enum GetType {
     /// Get the power
     #[structopt(name = "power")]
     Power {
+        #[structopt(short, long)]
+        raw: bool,
+    },
+    
+    /// Get the power
+    #[structopt(name = "usage")]
+    Usage {
         #[structopt(short, long)]
         raw: bool,
     },
@@ -209,6 +216,13 @@ fn parse_args(config: config::Config) {
                 },
                 Err(_) => eprintln!("Failed to get read lid state"),
             },
+
+            GetType::Usage { raw } => match get_cpu_percent() {
+                Ok(content) => {
+                    println!("{}", content)
+                },
+                Err(_) => println!("Unable to usage status")
+            }
 
             GetType::Turbo { raw } => match check_turbo_enabled() {
                 Ok(turbo_enabled) => print_turbo(turbo_enabled, raw),

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use power::{read_battery_charge, read_lid_state, read_power_source};
 use settings::Settings;
 use system::{
     check_available_governors, check_cpu_freq, check_cpu_name, check_turbo_enabled,
-    list_cpu_governors, list_cpu_speeds, list_cpu_temp, list_cpus, get_cpu_percent,
+    get_cpu_percent, list_cpu_governors, list_cpu_speeds, list_cpu_temp, list_cpus,
 };
 
 pub mod config;
@@ -36,7 +36,7 @@ enum GetType {
         #[structopt(short, long)]
         raw: bool,
     },
-    
+
     /// Get the power
     #[structopt(name = "usage")]
     Usage {
@@ -220,9 +220,9 @@ fn parse_args(config: config::Config) {
             GetType::Usage { raw } => match get_cpu_percent() {
                 Ok(content) => {
                     println!("{}", content)
-                },
-                Err(_) => println!("Unable to usage status")
-            }
+                }
+                Err(_) => println!("Unable to usage status"),
+            },
 
             GetType::Turbo { raw } => match check_turbo_enabled() {
                 Ok(turbo_enabled) => print_turbo(turbo_enabled, raw),

--- a/src/system.rs
+++ b/src/system.rs
@@ -96,7 +96,7 @@ fn parse_proc_file(proc: String) -> Result<Vec<ProcStat>, Error> {
                 }
             }
 
-            match columns[6].parse::<f32>() {
+            match columns[5].parse::<f32>() {
                 Ok(num) => {
                     proc_struct.cpu_idle = num;
                 },
@@ -110,9 +110,6 @@ fn parse_proc_file(proc: String) -> Result<Vec<ProcStat>, Error> {
 
 pub fn get_cpu_percent() -> Result<String, Error> {
     let mut proc = read_proc_stat_file().unwrap();
-    
-    // Since were getting the average just get the first one which is equal to the average of all
-    // others
     let mut avg_timing: &ProcStat = &parse_proc_file(proc).unwrap()[0];
 
     thread::sleep(time::Duration::from_millis(1000));
@@ -120,9 +117,12 @@ pub fn get_cpu_percent() -> Result<String, Error> {
 
     let mut avg_timing_2: &ProcStat = &parse_proc_file(proc).unwrap()[0];
 
-    println!("{:?} and {:?}", avg_timing, avg_timing_2);
+    let cpu_delta: f32 = avg_timing_2.cpu_sum - avg_timing.cpu_sum;
+    let cpu_delta_idle: f32 = avg_timing_2.cpu_idle - avg_timing.cpu_idle;
+    let cpu_used: f32 = cpu_delta - cpu_delta_idle;
+    let usage: f32 = cpu_used / cpu_delta * 100.0;
 
-    Ok("...".to_string())
+    Ok(format!("{}", usage))
 }
 
 fn read_turbo_file() -> Result<String, Error> {

--- a/src/system.rs
+++ b/src/system.rs
@@ -113,12 +113,12 @@ fn parse_proc_file(proc: String) -> Result<Vec<ProcStat>, Error> {
 
 pub fn get_cpu_percent() -> Result<String, Error> {
     let mut proc = read_proc_stat_file().unwrap();
-    let mut avg_timing: &ProcStat = &parse_proc_file(proc).unwrap()[0];
+    let avg_timing: &ProcStat = &parse_proc_file(proc).unwrap()[0];
 
     thread::sleep(time::Duration::from_millis(1000));
     proc = read_proc_stat_file().unwrap();
 
-    let mut avg_timing_2: &ProcStat = &parse_proc_file(proc).unwrap()[0];
+    let avg_timing_2: &ProcStat = &parse_proc_file(proc).unwrap()[0];
 
     let cpu_delta: f32 = avg_timing_2.cpu_sum - avg_timing.cpu_sum;
     let cpu_delta_idle: f32 = avg_timing_2.cpu_idle - avg_timing.cpu_idle;

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,8 +1,8 @@
 use cached::proc_macro::once;
 use std::fs::{read_dir, File};
-use std::{thread, time};
 use std::io::Read;
 use std::string::String;
+use std::{thread, time};
 
 use crate::cpu::Speed;
 
@@ -73,7 +73,11 @@ struct ProcStat {
 
 impl Default for ProcStat {
     fn default() -> ProcStat {
-        ProcStat{cpu_name: "cpu".to_string(), cpu_sum: 0.0, cpu_idle: 0.0}
+        ProcStat {
+            cpu_name: "cpu".to_string(),
+            cpu_sum: 0.0,
+            cpu_idle: 0.0,
+        }
     }
 }
 
@@ -86,12 +90,11 @@ fn parse_proc_file(proc: String) -> Result<Vec<ProcStat>, Error> {
             let mut proc_struct: ProcStat = ProcStat::default();
             proc_struct.cpu_name = columns[0].to_string();
             for col in &columns {
-
                 let parse = col.parse::<f32>();
                 match parse {
                     Ok(num) => {
                         proc_struct.cpu_sum += num;
-                    },
+                    }
                     Err(_) => {}
                 }
             }
@@ -99,7 +102,7 @@ fn parse_proc_file(proc: String) -> Result<Vec<ProcStat>, Error> {
             match columns[5].parse::<f32>() {
                 Ok(num) => {
                     proc_struct.cpu_idle = num;
-                },
+                }
                 Err(_) => {}
             }
             procs.push(proc_struct);

--- a/src/system.rs
+++ b/src/system.rs
@@ -269,6 +269,13 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_proc_stat_file() {
+        let cpu_percent = get_cpu_percent().unwrap().parse::<f32>().unwrap();
+        assert_eq!(type_of(cpu_percent), type_of(0.0_f32));
+        assert!(cpu_percent > 0.0 && cpu_percent < 100.0);
+    }
+
+    #[test]
     fn get_name_from_cpu_info_unit_test() -> Result<(), Error> {
         let cpu_info = String::from(
             "


### PR DESCRIPTION
`acs get usage`
This only adds the ability to get the CPU usage but it doesn't display it on a per core basis in acs monit. I will make that work later.