### PR TITLE
New graphing modes for --graph

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use super::logger::Interface;
 use super::power::{has_battery, read_battery_charge, read_lid_state, read_power_source, LidState};
 use super::state::State;
 use super::system::{
-    check_available_governors, check_cpu_freq, check_turbo_enabled, get_highest_temp, list_cpus,
+    check_available_governors, check_cpu_freq, check_cpu_usage, check_turbo_enabled, get_highest_temp, list_cpus,
     parse_proc_file, read_proc_stat_file, ProcStat,
 };
 use super::terminal::terminal_width;
@@ -475,7 +475,7 @@ impl Checker for Daemon {
 
         // Update the data in the graph and render it
         if self.settings.should_graph {
-            self.grapher.freqs.push(check_cpu_freq() as f64);
+            self.grapher.vals.push(check_cpu_usage(&self.cpus) as f64);
         }
 
         Ok(())
@@ -531,7 +531,7 @@ impl Checker for Daemon {
 
         // Compute graph before screen is cleared
         if self.settings.should_graph {
-            self.graph = self.grapher.update_one(&mut self.grapher.freqs.clone());
+            self.graph = self.grapher.update_one(&mut self.grapher.vals.clone());
         }
 
         let term_width = terminal_width();
@@ -687,7 +687,7 @@ pub fn daemon_init(settings: Settings, config: Config) -> Result<Daemon, Error> 
         already_high_usage: false,
         last_below_cpu_usage_percent: None,
         graph: String::new(),
-        grapher: Graph { freqs: vec![0.0] },
+        grapher: Graph { vals: vec![0.0] },
         temp_max: 0,
         commit_hash: String::new(),
         timeout: time::Duration::from_millis(1),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -326,6 +326,9 @@ impl Checker for Daemon {
         if self.settings.graph == GraphType::Usage {
             self.grapher.vals.push(check_cpu_usage(&self.cpus) as f64);
         }
+        if self.settings.graph == GraphType::Frequency {
+            self.grapher.vals.push(check_cpu_freq(&self.cpus) as f64);
+        }
 
         Ok(())
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12,7 +12,7 @@ use super::logger;
 use super::logger::Interface;
 use super::power::{has_battery, read_battery_charge, read_lid_state, read_power_source, LidState};
 use super::system::{
-    check_available_governors, check_cpu_freq, check_cpu_usage, check_turbo_enabled, get_highest_temp, list_cpus,
+    check_available_governors, check_cpu_temperature, check_cpu_freq, check_cpu_usage, check_turbo_enabled, get_highest_temp, list_cpus,
     parse_proc_file, read_proc_stat_file, ProcStat,
 };
 use super::terminal::terminal_width;
@@ -328,6 +328,9 @@ impl Checker for Daemon {
         }
         if self.settings.graph == GraphType::Frequency {
             self.grapher.vals.push(check_cpu_freq(&self.cpus) as f64);
+        }
+        if self.settings.graph == GraphType::Temperature {
+            self.grapher.vals.push((check_cpu_temperature(&self.cpus) / 1000.0) as f64);
         }
 
         Ok(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,13 +11,14 @@ use super::graph::{Graph, Grapher};
 use super::logger;
 use super::logger::Interface;
 use super::power::{has_battery, read_battery_charge, read_lid_state, read_power_source, LidState};
+use super::settings::{GraphType, Settings};
 use super::system::{
-    check_available_governors, check_cpu_temperature, check_cpu_freq, check_cpu_usage, check_turbo_enabled, get_highest_temp, list_cpus,
-    parse_proc_file, read_proc_stat_file, ProcStat,
+    check_available_governors, check_cpu_freq, check_cpu_temperature, check_cpu_usage,
+    check_turbo_enabled, get_highest_temp, list_cpus, parse_proc_file, read_proc_stat_file,
+    ProcStat,
 };
 use super::terminal::terminal_width;
 use super::Error;
-use super::settings::{GraphType, Settings};
 use crate::display::print_turbo_animation;
 use crate::warn_user;
 
@@ -330,7 +331,9 @@ impl Checker for Daemon {
             self.grapher.vals.push(check_cpu_freq(&self.cpus) as f64);
         }
         if self.settings.graph == GraphType::Temperature {
-            self.grapher.vals.push((check_cpu_temperature(&self.cpus) / 1000.0) as f64);
+            self.grapher
+                .vals
+                .push((check_cpu_temperature(&self.cpus) / 1000.0) as f64);
         }
 
         Ok(())
@@ -574,7 +577,7 @@ mod tests {
             delay_battery: 2,
             edit: true,
             no_animation: false,
-            should_graph: false,
+            graph: GraphType::Hidden,
             commit: false,
             testing: true,
         };
@@ -593,7 +596,7 @@ mod tests {
             delay_battery: 2,
             edit: true,
             no_animation: false,
-            should_graph: false,
+            graph: GraphType::Hidden,
             commit: false,
             testing: true,
         };
@@ -618,7 +621,7 @@ mod tests {
             delay_battery: 2,
             edit: false,
             no_animation: false,
-            should_graph: false,
+            graph: GraphType::Hidden,
             commit: false,
             testing: true,
         };

--- a/src/display.rs
+++ b/src/display.rs
@@ -29,11 +29,11 @@ pub fn show_config() {
     println!("{}", get_config());
 }
 
-pub fn print_freq(f: i32, raw: bool) {
+pub fn print_freq(f: f32, raw: bool) {
     if raw {
         println!("{}", f);
     } else {
-        println!("CPU freq is {} MHz", f / 1000)
+        println!("CPU freq is {} MHz", f / 1000.0)
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -8,12 +8,12 @@ pub trait Grapher {
 }
 
 pub struct Graph {
-    pub freqs: Vec<f64>,
+    pub vals: Vec<f64>,
 }
 
 impl Grapher for Graph {
     fn update_all(&mut self) {
-        self.update_one(&mut self.freqs.clone());
+        self.update_one(&mut self.vals.clone());
     }
 
     fn update_one(&self, vec: &mut Vec<f64>) -> String {

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,6 +1,6 @@
 use super::config::{get_config, Config};
 use super::interface::{Get, Getter, Interface, Set, Setter};
-use super::settings::{ GraphType, Settings };
+use super::settings::{GraphType, Settings};
 use colored::Colorize;
 use std::io::{stdin, stdout, Write};
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,6 +1,6 @@
 use super::config::{get_config, Config};
 use super::interface::{Get, Getter, Interface, Set, Setter};
-use super::settings::Settings;
+use super::settings::{ GraphType, Settings };
 use colored::Colorize;
 use std::io::{stdin, stdout, Write};
 
@@ -39,7 +39,7 @@ pub fn interactive() {
         delay: 0,
         edit: false,
         no_animation: false,
-        should_graph: false,
+        graph: GraphType::Hidden,
         commit: false,
         testing: false,
     };

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -27,7 +27,7 @@ pub trait Getter {
 
 impl Getter for Get {
     fn freq(&self, raw: bool) {
-        let f = check_cpu_freq();
+        let f = check_cpu_freq(&list_cpus());
         print_freq(f, raw);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ fn parse_args(config: config::Config) {
                 warn_user!("Config directory '/etc/acs' does not exist!");
                 thread::sleep(time::Duration::from_millis(5000));
             }
-            
+
             let mut parsed_graph_type = GraphType::Hidden;
 
             match graph_type {
@@ -271,8 +271,7 @@ fn parse_args(config: config::Config) {
                         thread::sleep(time::Duration::from_millis(5000));
                     }
                 }
-                None => {
-                }
+                None => {}
             }
 
             let mut effective_delay_battery = delay_battery;
@@ -322,8 +321,7 @@ fn parse_args(config: config::Config) {
                         thread::sleep(time::Duration::from_millis(5000));
                     }
                 }
-                None => {
-                }
+                None => {}
             }
 
             let mut effective_delay_battery = delay_battery;

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ enum ACSCommand {
 
         /// Graph
         #[structopt(short = "g", long = "--graph")]
-        should_graph: Option<String>,
+        graph_type: Option<String>,
 
         /// Commit hash
         #[structopt(short, long)]
@@ -175,7 +175,7 @@ enum ACSCommand {
 
         /// Graph
         #[structopt(short = "g", long = "--graph")]
-        should_graph: Option<String>,
+        graph_type: Option<String>,
 
         /// Commit hash
         #[structopt(short, long)]
@@ -253,7 +253,7 @@ fn parse_args(config: config::Config) {
             delay,
             delay_battery,
             no_animation,
-            should_graph,
+            graph_type,
             commit,
         } => {
             if !config_dir_exists() {
@@ -263,7 +263,7 @@ fn parse_args(config: config::Config) {
             
             let mut parsed_graph_type = GraphType::Hidden;
 
-            match should_graph {
+            match graph_type {
                 Some(graph_name) => {
                     parsed_graph_type = get_graph_type(&graph_name);
                     if parsed_graph_type == GraphType::Unknown {
@@ -305,7 +305,7 @@ fn parse_args(config: config::Config) {
             delay,
             delay_battery,
             no_animation,
-            should_graph,
+            graph_type,
             commit,
         } => {
             if !config_dir_exists() {
@@ -314,7 +314,7 @@ fn parse_args(config: config::Config) {
 
             let mut parsed_graph_type = GraphType::Hidden;
 
-            match should_graph {
+            match graph_type {
                 Some(graph_name) => {
                     parsed_graph_type = get_graph_type(&graph_name);
                     if parsed_graph_type == GraphType::Unknown {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use display::show_config;
 use error::Error;
 use interactive::interactive;
 use interface::{Get, Getter, Interface, Set, Setter};
-use settings::Settings;
+use settings::{Settings, GraphType, get_graph_type};
 
 pub mod config;
 pub mod cpu;
@@ -104,6 +104,7 @@ enum SetType {
     name = "autoclockspeed",
     about = "Automatic CPU frequency scaler and power saver"
 )]
+
 enum ACSCommand {
     /// Get a specific value or status
     #[structopt(name = "get", alias = "g")]
@@ -148,8 +149,8 @@ enum ACSCommand {
         no_animation: bool,
 
         /// Graph
-        #[structopt(short = "g", long = "--graph")]
-        should_graph: bool,
+        #[structopt(short = "g", long = "--graph", default_value = "none")]
+        should_graph: String,
 
         /// Commit hash
         #[structopt(short, long)]
@@ -172,8 +173,8 @@ enum ACSCommand {
         no_animation: bool,
 
         /// Graph
-        #[structopt(short = "g", long = "--graph")]
-        should_graph: bool,
+        #[structopt(short = "g", long = "--graph", default_value = "none")]
+        should_graph: String,
 
         /// Commit hash
         #[structopt(short, long)]
@@ -190,7 +191,7 @@ fn parse_args(config: config::Config) {
         delay: 0,
         edit: false,
         no_animation: false,
-        should_graph: false,
+        should_graph: GraphType::Hidden,
         commit: false,
         testing: false,
     };
@@ -259,7 +260,7 @@ fn parse_args(config: config::Config) {
             }
 
             let mut effective_delay_battery = delay_battery;
-            if should_graph || delay != 1000 {
+            if should_graph|| delay != 1000 {
                 effective_delay_battery = delay;
             }
 
@@ -269,7 +270,7 @@ fn parse_args(config: config::Config) {
                 delay,
                 edit: true,
                 no_animation,
-                should_graph,
+                graph_type: get_graph_type(should_graph),
                 commit,
                 testing: false,
             };
@@ -306,7 +307,7 @@ fn parse_args(config: config::Config) {
                 delay_battery: effective_delay_battery,
                 edit: false,
                 no_animation,
-                should_graph,
+                graph_type: get_graph_type(should_graph),
                 commit,
                 testing: false,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use log::debug;
 use structopt::StructOpt;
+use std::{thread, time};
 
 use config::{config_dir_exists, get_config};
 use daemon::{daemon_init, Checker};
@@ -257,9 +258,17 @@ fn parse_args(config: config::Config) {
         } => {
             if !config_dir_exists() {
                 warn_user!("Config directory '/etc/acs' does not exist!");
+                thread::sleep(time::Duration::from_millis(5000));
             }
 
-            let parsed_graph_type = get_graph_type(&should_graph);
+            let parsed_graph_type = match get_graph_type(&should_graph) {
+                Some(graph_type) => graph_type,
+                None => {
+                    warn_user!("Graph type is not set! Can be hidden, frequency, frequency_individual, usage, usage_individual, temperature, temperature_individual. Continuing in 5 seconds...");
+                    thread::sleep(time::Duration::from_millis(5000));
+                    GraphType::Hidden
+                }
+            };
 
             let mut effective_delay_battery = delay_battery;
             if parsed_graph_type != GraphType::Hidden || delay != 1000 {
@@ -297,8 +306,16 @@ fn parse_args(config: config::Config) {
             if !config_dir_exists() {
                 warn_user!("Config directory '/etc/acs' does not exist!");
             }
+            
 
-            let parsed_graph_type = get_graph_type(&should_graph);
+            let parsed_graph_type = match get_graph_type(&should_graph) {
+                Some(graph_type) => graph_type,
+                None => {
+                    warn_user!("Graph type is not set! Can be hidden, frequency, frequency_individual, usage, usage_individual, temperature, temperature_individual. Continuing in 5 seconds...");
+                    thread::sleep(time::Duration::from_millis(5000));
+                    GraphType::Hidden
+                }
+            };
 
             let mut effective_delay_battery = delay_battery;
             if parsed_graph_type != GraphType::Hidden || delay != 1000 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,8 +150,8 @@ enum ACSCommand {
         no_animation: bool,
 
         /// Graph
-        #[structopt(short = "g", long = "--graph", default_value = "none")]
-        should_graph: String,
+        #[structopt(short = "g", long = "--graph")]
+        should_graph: Option<String>,
 
         /// Commit hash
         #[structopt(short, long)]
@@ -174,8 +174,8 @@ enum ACSCommand {
         no_animation: bool,
 
         /// Graph
-        #[structopt(short = "g", long = "--graph", default_value = "none")]
-        should_graph: String,
+        #[structopt(short = "g", long = "--graph")]
+        should_graph: Option<String>,
 
         /// Commit hash
         #[structopt(short, long)]
@@ -260,15 +260,20 @@ fn parse_args(config: config::Config) {
                 warn_user!("Config directory '/etc/acs' does not exist!");
                 thread::sleep(time::Duration::from_millis(5000));
             }
+            
+            let mut parsed_graph_type = GraphType::Hidden;
 
-            let parsed_graph_type = match get_graph_type(&should_graph) {
-                Some(graph_type) => graph_type,
-                None => {
-                    warn_user!("Graph type is not set! Can be freq, usage, or temp Continuing in 5 seconds...");
-                    thread::sleep(time::Duration::from_millis(5000));
-                    GraphType::Hidden
+            match should_graph {
+                Some(graph_name) => {
+                    parsed_graph_type = get_graph_type(&graph_name);
+                    if parsed_graph_type == GraphType::Unknown {
+                        warn_user!("Graph type does not exist! Can be freq, usage, or temp Continuing in 5 seconds...");
+                        thread::sleep(time::Duration::from_millis(5000));
+                    }
                 }
-            };
+                None => {
+                }
+            }
 
             let mut effective_delay_battery = delay_battery;
             if parsed_graph_type != GraphType::Hidden || delay != 1000 {
@@ -307,14 +312,19 @@ fn parse_args(config: config::Config) {
                 warn_user!("Config directory '/etc/acs' does not exist!");
             }
 
-            let parsed_graph_type = match get_graph_type(&should_graph) {
-                Some(graph_type) => graph_type,
-                None => {
-                    warn_user!("Graph type is not set! Can be freq, usage, or temp Continuing in 5 seconds...");
-                    thread::sleep(time::Duration::from_millis(5000));
-                    GraphType::Hidden
+            let mut parsed_graph_type = GraphType::Hidden;
+
+            match should_graph {
+                Some(graph_name) => {
+                    parsed_graph_type = get_graph_type(&graph_name);
+                    if parsed_graph_type == GraphType::Unknown {
+                        warn_user!("Graph type does not exist! Can be freq, usage, or temp Continuing in 5 seconds...");
+                        thread::sleep(time::Duration::from_millis(5000));
+                    }
                 }
-            };
+                None => {
+                }
+            }
 
             let mut effective_delay_battery = delay_battery;
             if parsed_graph_type != GraphType::Hidden || delay != 1000 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,7 @@ fn parse_args(config: config::Config) {
         delay: 0,
         edit: false,
         no_animation: false,
-        should_graph: GraphType::Hidden,
+        graph: GraphType::Hidden,
         commit: false,
         testing: false,
     };
@@ -259,8 +259,10 @@ fn parse_args(config: config::Config) {
                 warn_user!("Config directory '/etc/acs' does not exist!");
             }
 
+            let parsed_graph_type = get_graph_type(&should_graph);
+
             let mut effective_delay_battery = delay_battery;
-            if should_graph|| delay != 1000 {
+            if parsed_graph_type != GraphType::Hidden || delay != 1000 {
                 effective_delay_battery = delay;
             }
 
@@ -270,7 +272,7 @@ fn parse_args(config: config::Config) {
                 delay,
                 edit: true,
                 no_animation,
-                graph_type: get_graph_type(should_graph),
+                graph: parsed_graph_type,
                 commit,
                 testing: false,
             };
@@ -296,8 +298,10 @@ fn parse_args(config: config::Config) {
                 warn_user!("Config directory '/etc/acs' does not exist!");
             }
 
+            let parsed_graph_type = get_graph_type(&should_graph);
+
             let mut effective_delay_battery = delay_battery;
-            if should_graph || delay != 1000 {
+            if parsed_graph_type != GraphType::Hidden || delay != 1000 {
                 effective_delay_battery = delay;
             }
 
@@ -307,7 +311,7 @@ fn parse_args(config: config::Config) {
                 delay_battery: effective_delay_battery,
                 edit: false,
                 no_animation,
-                graph_type: get_graph_type(should_graph),
+                graph: parsed_graph_type,
                 commit,
                 testing: false,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use log::debug;
-use structopt::StructOpt;
 use std::{thread, time};
+use structopt::StructOpt;
 
 use config::{config_dir_exists, get_config};
 use daemon::{daemon_init, Checker};
@@ -8,7 +8,7 @@ use display::show_config;
 use error::Error;
 use interactive::interactive;
 use interface::{Get, Getter, Interface, Set, Setter};
-use settings::{Settings, GraphType, get_graph_type};
+use settings::{get_graph_type, GraphType, Settings};
 
 pub mod config;
 pub mod cpu;
@@ -306,7 +306,6 @@ fn parse_args(config: config::Config) {
             if !config_dir_exists() {
                 warn_user!("Config directory '/etc/acs' does not exist!");
             }
-            
 
             let parsed_graph_type = match get_graph_type(&should_graph) {
                 Some(graph_type) => graph_type,

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ fn parse_args(config: config::Config) {
             let parsed_graph_type = match get_graph_type(&should_graph) {
                 Some(graph_type) => graph_type,
                 None => {
-                    warn_user!("Graph type is not set! Can be hidden, frequency, frequency_individual, usage, usage_individual, temperature, temperature_individual. Continuing in 5 seconds...");
+                    warn_user!("Graph type is not set! Can be freq, usage, or temp Continuing in 5 seconds...");
                     thread::sleep(time::Duration::from_millis(5000));
                     GraphType::Hidden
                 }
@@ -311,7 +311,7 @@ fn parse_args(config: config::Config) {
             let parsed_graph_type = match get_graph_type(&should_graph) {
                 Some(graph_type) => graph_type,
                 None => {
-                    warn_user!("Graph type is not set! Can be hidden, frequency, frequency_individual, usage, usage_individual, temperature, temperature_individual. Continuing in 5 seconds...");
+                    warn_user!("Graph type is not set! Can be freq, usage, or temp Continuing in 5 seconds...");
                     thread::sleep(time::Duration::from_millis(5000));
                     GraphType::Hidden
                 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,16 +9,16 @@ pub enum GraphType {
     TemperatureIndividual,
 }
 
-pub fn get_graph_type(graph_type: &str) -> GraphType {
+pub fn get_graph_type(graph_type: &str) -> Option<GraphType> {
     match graph_type.to_lowercase().as_str() {
-        "hidden" => GraphType::Hidden,
-        "frequency" => GraphType::Frequency,
-        "frequency_individual" => GraphType::FrequencyIndividual,
-        "usage" => GraphType::Usage,
-        "usage_individual" => GraphType::UsageIndividual,
-        "temperature" => GraphType::Temperature,
-        "temperature_individual" => GraphType::TemperatureIndividual,
-        _ => GraphType::Hidden,
+        "hidden" => Some(GraphType::Hidden),
+        "frequency" => Some(GraphType::Frequency),
+        "frequency_individual" => Some(GraphType::FrequencyIndividual),
+        "usage" => Some(GraphType::Usage),
+        "usage_individual" => Some(GraphType::UsageIndividual),
+        "temperature" => Some(GraphType::Temperature),
+        "temperature_individual" => Some(GraphType::TemperatureIndividual),
+        _ => None,
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,27 @@
+#[derive(PartialEq)]
+pub enum GraphType {
+    Hidden,
+    Frequency,
+    FrequencyIndividual,
+    Usage,
+    UsageIndividual,
+    Temperature,
+    TemperatureIndividual,
+}
+
+pub fn get_graph_type(graph_type: &str) -> GraphType {
+    match graph_type.to_lowercase().as_str() {
+        "hidden" => GraphType::Hidden,
+        "frequency" => GraphType::Frequency,
+        "frequency_individual" => GraphType::FrequencyIndividual,
+        "usage" => GraphType::Usage,
+        "usage_individual" => GraphType::UsageIndividual,
+        "temperature" => GraphType::Temperature,
+        "temperature_individual" => GraphType::TemperatureIndividual,
+        _ => GraphType::Hidden,
+    }
+}
+
 #[derive(Clone)]
 pub struct Settings {
     pub verbose: bool,
@@ -5,7 +29,7 @@ pub struct Settings {
     pub delay_battery: u64,
     pub edit: bool,
     pub no_animation: bool,
-    pub should_graph: bool,
+    pub should_graph: GraphType,
     pub commit: bool,
     pub testing: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub enum GraphType {
     Hidden,
     Frequency,
@@ -29,7 +29,7 @@ pub struct Settings {
     pub delay_battery: u64,
     pub edit: bool,
     pub no_animation: bool,
-    pub should_graph: GraphType,
+    pub graph: GraphType,
     pub commit: bool,
     pub testing: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,15 +4,16 @@ pub enum GraphType {
     Frequency,
     Usage,
     Temperature,
+    Unknown,
 }
 
-pub fn get_graph_type(graph_type: &str) -> Option<GraphType> {
+pub fn get_graph_type(graph_type: &str) -> GraphType {
     match graph_type.to_lowercase().as_str() {
-        "hidden" => Some(GraphType::Hidden),
-        "freq" => Some(GraphType::Frequency),
-        "usage" => Some(GraphType::Usage),
-        "temp" => Some(GraphType::Temperature),
-        _ => None,
+        "hidden" => GraphType::Hidden,
+        "freq" => GraphType::Frequency,
+        "usage" => GraphType::Usage,
+        "temp" => GraphType::Temperature,
+        _ => GraphType::Unknown,
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,22 +2,16 @@
 pub enum GraphType {
     Hidden,
     Frequency,
-    FrequencyIndividual,
     Usage,
-    UsageIndividual,
     Temperature,
-    TemperatureIndividual,
 }
 
 pub fn get_graph_type(graph_type: &str) -> Option<GraphType> {
     match graph_type.to_lowercase().as_str() {
         "hidden" => Some(GraphType::Hidden),
-        "frequency" => Some(GraphType::Frequency),
-        "frequency_individual" => Some(GraphType::FrequencyIndividual),
+        "freq" => Some(GraphType::Frequency),
         "usage" => Some(GraphType::Usage),
-        "usage_individual" => Some(GraphType::UsageIndividual),
-        "temperature" => Some(GraphType::Temperature),
-        "temperature_individual" => Some(GraphType::TemperatureIndividual),
+        "temp" => Some(GraphType::Temperature),
         _ => None,
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -19,7 +19,10 @@ pub fn check_cpu_freq(cpus: &Vec<CPU>) -> f32 {
 
 /// Find the average usage of all cores
 pub fn check_cpu_usage(cpus: &Vec<CPU>) -> f32 {
-    let usage: Vec<i32> = cpus.into_iter().map(|x| (x.cur_usage * 100.0) as i32).collect();
+    let usage: Vec<i32> = cpus
+        .into_iter()
+        .map(|x| (x.cur_usage * 100.0) as i32)
+        .collect();
     let sum: i32 = Iterator::sum(usage.iter());
     sum as f32 / usage.len() as f32
 }
@@ -30,7 +33,6 @@ pub fn check_cpu_temperature(cpus: &Vec<CPU>) -> f32 {
     let sum: i32 = Iterator::sum(usage.iter());
     sum as f32 / usage.len() as f32
 }
-
 
 pub fn get_highest_temp(cpus: &Vec<CPU>) -> i32 {
     let mut temp_max: i32 = 0;
@@ -298,8 +300,7 @@ mod tests {
 
     #[test]
     fn check_cpu_freq_acs_test() {
-        assert_eq!(type_of(check_cpu_freq()), type_of(1));
-        assert!(check_cpu_freq() > 0);
+        assert!(check_cpu_freq(&list_cpus()) > 0.0);
     }
 
     #[test]

--- a/src/system.rs
+++ b/src/system.rs
@@ -17,6 +17,14 @@ pub fn check_cpu_freq() -> i32 {
     (sum as f32 / freqs.len() as f32) as i32
 }
 
+/// Check the usage of the cpu
+pub fn check_cpu_usage(cpus: &Vec<CPU>) -> i32 {
+    let usage: Vec<i32> = cpus.into_iter().map(|x| (x.cur_usage * 100.0) as i32).collect();
+    let sum: i32 = Iterator::sum(usage.iter());
+    (sum as f32 / usage.len() as f32) as i32
+}
+
+
 pub fn get_highest_temp(cpus: &Vec<CPU>) -> i32 {
     let mut temp_max: i32 = 0;
     for cpu in cpus {

--- a/src/system.rs
+++ b/src/system.rs
@@ -10,18 +10,25 @@ use crate::debug;
 use super::cpu::CPU;
 use super::Error;
 
-/// Check the frequency of the cpu
+/// Find the average frequency of all cores
 pub fn check_cpu_freq(cpus: &Vec<CPU>) -> f32 {
     let freqs: Vec<i32> = cpus.into_iter().map(|x| x.cur_freq).collect();
     let sum: i32 = Iterator::sum(freqs.iter());
-    (sum as f32 / freqs.len() as f32)
+    sum as f32 / freqs.len() as f32
 }
 
-/// Check the usage of the cpu
+/// Find the average usage of all cores
 pub fn check_cpu_usage(cpus: &Vec<CPU>) -> f32 {
     let usage: Vec<i32> = cpus.into_iter().map(|x| (x.cur_usage * 100.0) as i32).collect();
     let sum: i32 = Iterator::sum(usage.iter());
-    (sum as f32 / usage.len() as f32)
+    sum as f32 / usage.len() as f32
+}
+
+/// Find the average temperature of all cores
+pub fn check_cpu_temperature(cpus: &Vec<CPU>) -> f32 {
+    let usage: Vec<i32> = cpus.into_iter().map(|x| x.cur_temp).collect();
+    let sum: i32 = Iterator::sum(usage.iter());
+    sum as f32 / usage.len() as f32
 }
 
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -11,17 +11,17 @@ use super::cpu::CPU;
 use super::Error;
 
 /// Check the frequency of the cpu
-pub fn check_cpu_freq() -> i32 {
-    let freqs: Vec<i32> = list_cpus().into_iter().map(|x| x.cur_freq).collect();
+pub fn check_cpu_freq(cpus: &Vec<CPU>) -> f32 {
+    let freqs: Vec<i32> = cpus.into_iter().map(|x| x.cur_freq).collect();
     let sum: i32 = Iterator::sum(freqs.iter());
-    (sum as f32 / freqs.len() as f32) as i32
+    (sum as f32 / freqs.len() as f32)
 }
 
 /// Check the usage of the cpu
-pub fn check_cpu_usage(cpus: &Vec<CPU>) -> i32 {
+pub fn check_cpu_usage(cpus: &Vec<CPU>) -> f32 {
     let usage: Vec<i32> = cpus.into_iter().map(|x| (x.cur_usage * 100.0) as i32).collect();
     let sum: i32 = Iterator::sum(usage.iter());
-    (sum as f32 / usage.len() as f32) as i32
+    (sum as f32 / usage.len() as f32)
 }
 
 


### PR DESCRIPTION
I added multiple new modes for different types of graphing. This includes graphing the CPU usage, CPU temperature, and CPU frequency. I also changed the way we parse the --graph command so that the user can provide a graph type.