### PR TITLE
Remove hard coded paths in Battery logic

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -475,7 +475,7 @@ pub fn daemon_init(settings: Settings, config: Config) -> Result<Arc<Mutex<Daemo
 
     // Create a new Daemon
     let mut daemon: Daemon = Daemon {
-        battery: Battery::new(),
+        battery: Battery::new()?,
         cpus: Vec::<CPU>::new(),
         last_proc: Vec::<ProcStat>::new(),
         message,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -35,7 +35,13 @@ impl Getter for Get {
     }
 
     fn power(&self, raw: bool) {
-        let mut battery = Battery::new();
+        let mut battery = match Battery::new() {
+            Ok(plugged) => plugged,
+            Err(_) => {
+                eprintln!("Failed to get battery");
+                return;
+            }
+        };
         let plugged = match read_power_source() {
             Ok(plugged) => plugged,
             Err(_) => {
@@ -125,7 +131,13 @@ impl Getter for Get {
     }
 
     fn bat_cond(&self, raw: bool) {
-        let mut battery = Battery::new();
+        let mut battery = match Battery::new() {
+            Ok(plugged) => plugged,
+            Err(_) => {
+                eprintln!("Failed to get battery");
+                return;
+            }
+        };
         match battery.get_condition() {
             Ok(bat_cond) => print_bat_cond(bat_cond, raw),
             Err(_) => println!("Failed to get battery condition"),


### PR DESCRIPTION
Remove hard-coded paths in favor of multiple dynamic paths to support various systems
Closes #395 