### PR TITLE
Cache path of device for both Lid and Power

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -47,7 +47,7 @@ use super::logger::Interface;
 use super::network::{hook, listen};
 use super::power::battery::{has_battery, Battery};
 use super::power::lid::{read_lid_state, LidState};
-use super::power::read_power_source;
+use super::power::{Power, PowerRetriever};
 use super::settings::{GraphType, Settings};
 use super::setup::{inside_docker_message, inside_wsl_message};
 use super::system::{
@@ -150,6 +150,7 @@ pub struct Daemon {
     pub settings: Settings,
     pub paused: bool,
     pub do_update_battery: bool,
+    pub power: Power,
 }
 
 fn make_gov_powersave(cpu: &mut CPU) -> Result<(), Error> {
@@ -358,7 +359,7 @@ impl Checker for Daemon {
         self.update_all()?;
 
         // Update current states
-        self.charging = read_power_source().unwrap_or(true);
+        self.charging = self.power.read_power_source().unwrap_or(true);
         self.charge = self.battery.capacity;
         self.lid_state = read_lid_state()?;
         self.usage = calculate_average_usage(&self.cpus) * 100.0;
@@ -383,7 +384,6 @@ impl Checker for Daemon {
 
             // Check if the state has changed since the last time we checked
             if self.state != state {
-                // Log the state change
                 self.logger.log(
                     &format!("State changed: {:?} -> {:?}", self.state, state,),
                     logger::Severity::Log,
@@ -655,6 +655,9 @@ pub fn daemon_init(settings: Settings, config: Config) -> Result<Arc<Mutex<Daemo
     let battery_present;
     let ac_present;
 
+    let power = Power::default();
+    power.set_best_path();
+
     // Create a new Daemon
     let mut daemon: Daemon = Daemon {
         battery: {
@@ -666,10 +669,11 @@ pub fn daemon_init(settings: Settings, config: Config) -> Result<Arc<Mutex<Daemo
         last_proc: Vec::<ProcStat>::new(),
         message,
         lid_state: LidState::Unknown,
+        power,
         // If edit is still true, then there is definitely a bool result to read_power_source
         // otherwise, there is a real problem, because there should be a power source possible
         charging: {
-            let source = read_power_source();
+            let source = power.read_power_source();
             ac_present = source.is_ok();
             source.unwrap_or(true)
         },

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -46,7 +46,7 @@ use super::logger;
 use super::logger::Interface;
 use super::network::{hook, listen};
 use super::power::battery::{has_battery, Battery};
-use super::power::lid::{read_lid_state, LidState};
+use super::power::lid::{Lid, LidRetriever, LidState};
 use super::power::{Power, PowerRetriever};
 use super::settings::{GraphType, Settings};
 use super::setup::{inside_docker_message, inside_wsl_message};
@@ -130,27 +130,33 @@ pub trait Checker {
 /// The daemon structure which contains information about the auto clock speed instance
 pub struct Daemon {
     pub battery: Battery,
+    pub power: Power,
+    pub lid: Lid,
+    pub lid_state: LidState,
+
+    pub config: Config,
+    pub settings: Settings,
+
+    pub state: State,
+
+    pub logger: logger::Logger,
+    pub grapher: Graph,
+
     pub cpus: Vec<CPU>,
     pub last_proc: Vec<ProcStat>,
     pub message: String,
-    pub lid_state: LidState,
     pub charging: bool,
     pub charge: i8,
     pub usage: f32,
-    pub logger: logger::Logger,
-    pub config: Config,
     pub last_below_cpu_usage_percent: Option<SystemTime>,
-    pub state: State,
     pub graph: String,
-    pub grapher: Graph,
     pub temp_max: i8,
     pub commit_hash: String,
-    pub timeout: time::Duration,
-    pub timeout_battery: time::Duration,
-    pub settings: Settings,
     pub paused: bool,
     pub do_update_battery: bool,
-    pub power: Power,
+
+    pub timeout: time::Duration,
+    pub timeout_battery: time::Duration,
 }
 
 fn make_gov_powersave(cpu: &mut CPU) -> Result<(), Error> {
@@ -361,7 +367,7 @@ impl Checker for Daemon {
         // Update current states
         self.charging = self.power.read_power_source().unwrap_or(true);
         self.charge = self.battery.capacity;
-        self.lid_state = read_lid_state()?;
+        self.lid_state = self.lid.read_lid_state()?;
         self.usage = calculate_average_usage(&self.cpus) * 100.0;
 
         self.write_csv();
@@ -655,8 +661,8 @@ pub fn daemon_init(settings: Settings, config: Config) -> Result<Arc<Mutex<Daemo
     let battery_present;
     let ac_present;
 
-    let power = Power::default();
-    power.set_best_path();
+    let power = Power::new();
+    let lid = Lid::new();
 
     // Create a new Daemon
     let mut daemon: Daemon = Daemon {
@@ -669,7 +675,7 @@ pub fn daemon_init(settings: Settings, config: Config) -> Result<Arc<Mutex<Daemo
         last_proc: Vec::<ProcStat>::new(),
         message,
         lid_state: LidState::Unknown,
-        power,
+        lid,
         // If edit is still true, then there is definitely a bool result to read_power_source
         // otherwise, there is a real problem, because there should be a power source possible
         charging: {
@@ -677,6 +683,7 @@ pub fn daemon_init(settings: Settings, config: Config) -> Result<Arc<Mutex<Daemo
             ac_present = source.is_ok();
             source.unwrap_or(true)
         },
+        power,
         charge: 100,
         usage: 0.0,
         logger: logger::Logger {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -6,7 +6,7 @@ use super::display::{
 };
 use super::power::battery::Battery;
 use super::power::lid::read_lid_state;
-use super::power::read_power_source;
+use super::power::{Power, PowerRetriever};
 use super::settings::Settings;
 use super::system::{
     check_available_governors, check_cpu_freq, check_cpu_name, check_turbo_enabled,
@@ -153,7 +153,10 @@ impl Getter for Get {
                 return;
             }
         };
-        let plugged = match read_power_source() {
+        let power = Power::default();
+        power.set_best_path();
+
+        let plugged = match power.read_power_source() {
             Ok(plugged) => plugged,
             Err(e) => {
                 eprintln!("Failed to get read power source, an error occured: {:?}", e);

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -5,7 +5,7 @@ use super::display::{
     print_cpu_temp, print_cpus, print_freq, print_power, print_turbo,
 };
 use super::power::battery::Battery;
-use super::power::lid::read_lid_state;
+use super::power::lid::{Lid, LidRetriever};
 use super::power::{Power, PowerRetriever};
 use super::settings::Settings;
 use super::system::{
@@ -153,8 +153,7 @@ impl Getter for Get {
                 return;
             }
         };
-        let power = Power::default();
-        power.set_best_path();
+        let power = Power::new();
 
         let plugged = match power.read_power_source() {
             Ok(plugged) => plugged,
@@ -164,7 +163,8 @@ impl Getter for Get {
             }
         };
 
-        let lid = match read_lid_state() {
+        let lid_struct = Lid::new();
+        let lid = match lid_struct.read_lid_state() {
             Ok(lid) => lid,
             Err(e) => {
                 eprintln!("Failed to get read lid state, an error occured: {:?}", e);

--- a/src/power.rs
+++ b/src/power.rs
@@ -6,16 +6,17 @@ use super::Error;
 pub mod battery;
 pub mod lid;
 
+#[derive(Default)]
 pub struct Power {
-    best_path: &'static str,
+    pub best_path: &'static str,
 }
 
-trait Retriever {
+pub trait PowerRetriever {
     fn set_best_path(&mut self) -> Result<(), Error>;
     fn read_power_source(&self) -> Result<bool, Error>;
 }
 
-impl Retriever for Power {
+impl PowerRetriever for Power {
     /// Called once at the start of read_power_source
     fn set_best_path(&mut self) -> Result<(), Error> {
         // Only loaded once
@@ -40,10 +41,7 @@ impl Retriever for Power {
 
     fn read_power_source(&self) -> Result<bool, Error> {
         // Set self.best_path or HdwNotFound
-        match self.set_best_path() {
-            Ok(a) => a,
-            Err(e) => return Err(e),
-        };
+        self.set_best_path()?;
 
         let mut pwr_str = fs::read_to_string(self.best_path)?;
 

--- a/src/power/lid.rs
+++ b/src/power/lid.rs
@@ -1,17 +1,70 @@
 use crate::create_issue;
-use crate::power::get_best_path;
 use crate::Error;
-use std::any::Any;
 use std::cmp::PartialEq;
 use std::fmt;
 use std::fs;
+use std::path::Path;
 
-const LID_STATUS_PATH: [&str; 4] = [
-    "/proc/acpi/button/lid/LID/state",
-    "/proc/acpi/button/lid/LID0/state",
-    "/proc/acpi/button/lid/LID1/state",
-    "/proc/acpi/button/lid/LID2/state",
-];
+#[derive(PartialEq, Eq)]
+pub enum LidState {
+    Open,
+    Closed,
+    Unapplicable,
+    Unknown,
+}
+
+pub struct Lid {
+    best_path: &'static str,
+}
+
+trait Retriever {
+    fn set_best_path(&mut self) -> Result<(), Error>;
+    fn read_lid_state(&self) -> Result<LidState, Error>;
+}
+
+impl Retriever for Lid {
+    fn set_best_path(&mut self) -> Result<(), Error> {
+        static lid_status_path: [&str; 4] = [
+            "/proc/acpi/button/lid/LID/state",
+            "/proc/acpi/button/lid/LID0/state",
+            "/proc/acpi/button/lid/LID1/state",
+            "/proc/acpi/button/lid/LID2/state",
+        ];
+
+        // Find if any AC power path exists
+        for path in lid_status_path.iter() {
+            if Path::new(path).exists() {
+                // Mutate Power struct and leave
+                self.best_path = path;
+                return Ok(());
+            }
+        }
+
+        Err(Error::HdwNotFound)
+    }
+
+    fn read_lid_state(&self) -> Result<LidState, Error> {
+        match self.set_best_path() {
+            Ok(path) => path,
+            Err(error) => {
+                eprintln!("Could not detect your lid state.");
+                create_issue!("If you are on a laptop");
+                return Ok(LidState::Unapplicable);
+            }
+        };
+
+        let lid_str = fs::read_to_string(self.best_path)?;
+
+        let state = if lid_str.contains("open") {
+            LidState::Open
+        } else if lid_str.contains("closed") {
+            LidState::Closed
+        } else {
+            LidState::Unknown
+        };
+        Ok(state)
+    }
+}
 
 impl fmt::Display for LidState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -22,39 +75,4 @@ impl fmt::Display for LidState {
             LidState::Unknown => write!(f, "unknown"),
         }
     }
-}
-
-#[derive(PartialEq, Eq)]
-pub enum LidState {
-    Open,
-    Closed,
-    Unapplicable,
-    Unknown,
-}
-
-pub fn read_lid_state() -> Result<LidState, Error> {
-    let path: &str = match get_best_path(LID_STATUS_PATH) {
-        Ok(path) => path,
-        Err(error) => {
-            if error.type_id() == Error::IO.type_id() {
-                // Make sure to return IO error if one occurs
-                return Err(error);
-            }
-            eprintln!("Could not detect your lid state.");
-            create_issue!("If you are on a laptop");
-            return Ok(LidState::Unapplicable);
-        }
-    };
-
-    let lid_str = fs::read_to_string(path)?;
-
-    let state = if lid_str.contains("open") {
-        LidState::Open
-    } else if lid_str.contains("closed") {
-        LidState::Closed
-    } else {
-        LidState::Unknown
-    };
-
-    Ok(state)
 }


### PR DESCRIPTION
- Previously both lid and power recall the function each time they are called, this results in a loop and 4 file exist checks each call

- Save two calls to get_best_path per daemon refresh.
- Save eight calls to path().exists() per daemon refresh.