### PR TITLE
Check if csv is enabled before csv write

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -370,7 +370,9 @@ impl Checker for Daemon {
         self.lid_state = self.lid.read_lid_state()?;
         self.usage = calculate_average_usage(&self.cpus) * 100.0;
 
-        self.write_csv();
+        if self.settings.csv_file.is_some() {
+            self.write_csv();
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This is a huge speed up if csv is not enabled. This entire green block doesn't get called.
![image](https://user-images.githubusercontent.com/35516367/201433268-e18a099d-dd4d-4756-8c4c-e7db9b09d26c.png)

closes #469 