### PR TITLE
allow uninlined_format_args for rust clippy

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Run rust-clippy
         run:
           cargo clippy
-          -- -A clippy::uninlined_format_args
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          -- -A clippy::uninlined_format_args
         continue-on-error: true
 
       - name: Upload analysis results to GitHub

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Run rust-clippy
         run:
           cargo clippy
+          -- -A clippy::uninlined_format_args
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
-          -- -A clippy::uninlined_format_args
         continue-on-error: true
 
       - name: Upload analysis results to GitHub

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -48,6 +48,7 @@ jobs:
           cargo clippy
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          -- -A clippy::uninlined_format_args
         continue-on-error: true
 
       - name: Upload analysis results to GitHub


### PR DESCRIPTION
clears up a bunch of security notifications