### PR TITLE
Optimize read lid state function

### DIFF
--- a/src/power/lid.rs
+++ b/src/power/lid.rs
@@ -63,14 +63,11 @@ impl LidRetriever for Lid {
 
         let lid_str = fs::read_to_string(self.best_path)?;
 
-        let state = if lid_str.contains("open") {
-            LidState::Open
-        } else if lid_str.contains("closed") {
-            LidState::Closed
-        } else {
-            LidState::Unknown
-        };
-        Ok(state)
+        Ok(match lid_str.split_whitespace().last().unwrap() {
+            "open" => LidState::Open,
+            "closed" => LidState::Closed,
+            _ => LidState::Unknown,
+        })
     }
 }
 


### PR DESCRIPTION
Reduced two contains checks into a single split_whitespace() call with a match statement. Fixes #465 