### PR TITLE
Fix panic when IO error for some cpu features

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -640,8 +640,19 @@ pub fn daemon_init(settings: Settings, config: Config) -> Arc<Mutex<Daemon>> {
     }
 
     // Make a cpu struct for each cpu listed
-    for cpu in list_cpus() {
-        daemon.cpus.push(cpu);
+    match list_cpus() {
+        Ok(cpus) => {
+
+            for cpu in cpus {
+                daemon.cpus.push(cpu);
+            }
+
+        },
+        Err(e) => {
+
+            daemon.logger.log(&format!("Failed to read from CPUs: {:?}", e), logger::Severity::Error)
+
+        },
     }
 
     let daemon_mutex = Arc::new(Mutex::new(daemon));

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -141,8 +141,15 @@ pub trait Getter {
 
 impl Getter for Get {
     fn freq(&self, raw: bool) {
-        let f = check_cpu_freq(&list_cpus());
-        print_freq(f, raw);
+        match list_cpus() {
+            Ok(cpus) => {
+                let f = check_cpu_freq(&cpus);
+                print_freq(f, raw);
+            },
+            Err(e) => {
+                eprint!("Failed to get cpu information, an error occured: {:?}", e);
+            },
+        }
     }
 
     fn power(&self, raw: bool) {
@@ -230,26 +237,54 @@ impl Getter for Get {
     }
 
     fn cpus(&self, raw: bool) {
-        let cpus = list_cpus();
-        match check_cpu_name() {
-            Ok(name) => print_cpus(cpus, name, raw),
-            Err(_) => println!("Failed get list of cpus"),
-        };
+        let cpus_result = list_cpus();
+        match cpus_result {
+            Ok(cpus) => {
+                match check_cpu_name() {
+                    Ok(name) => print_cpus(cpus, name, raw),
+                    Err(_) => println!("Failed get list of cpus"),
+                };
+            },
+            Err(e) => {
+                eprintln!("Failed to get cpu information, an error occured: {:?}", e);
+            },
+        }
     }
 
     fn speeds(&self, raw: bool) {
-        let speeds = list_cpu_speeds();
-        print_cpu_speeds(speeds, raw);
+        let speeds_result = list_cpu_speeds();
+        match speeds_result {
+            Ok(speeds) => {
+                print_cpu_speeds(speeds, raw);
+            },
+            Err(e) => {
+                eprintln!("Failed to get cpu speed information, an error occured: {:?}", e);
+            },
+        }
     }
 
     fn temp(&self, raw: bool) {
-        let cpu_temp = list_cpu_temp();
-        print_cpu_temp(cpu_temp, raw);
+        let cpu_temp_result = list_cpu_temp();
+        match cpu_temp_result {
+            Ok(cpu_temp) => {
+                print_cpu_temp(cpu_temp, raw);
+            },
+            Err(e) => {
+                eprintln!("Failed to get cpu temperature information, an error occured: {:?}", e);
+            },
+        }
     }
 
     fn govs(&self, raw: bool) {
-        let govs = list_cpu_governors();
-        print_cpu_governors(govs, raw);
+        let govs_result = list_cpu_governors();
+        match govs_result {
+            Ok(govs) => {
+                print_cpu_governors(govs, raw);
+            },
+            Err(e) => {
+                eprintln!("Failed to get cpu governor information, an error occured: {:?}", e);
+            },
+        }
     }
 
     fn bat_cond(&self, raw: bool) {

--- a/src/system.rs
+++ b/src/system.rs
@@ -182,8 +182,7 @@ pub fn check_available_governors() -> Result<Vec<String>, Error> {
 }
 
 /// Get all the cpus (cores), returns cpus from 0 to the (amount of cores -1) the machine has
-#[once]
-pub fn list_cpus() -> Vec<CPU> {
+pub fn list_cpus() -> Result<Vec<CPU>, Error> {
     let mut cpus: Vec<String> = Vec::<String>::new();
 
     // Get each item in the cpu directory
@@ -228,30 +227,30 @@ pub fn list_cpus() -> Vec<CPU> {
             gov: "Unknown".to_string(),
         };
 
-        new.init_cpu().unwrap();
+        new.init_cpu()?;
 
-        new.update().unwrap();
+        new.update()?;
 
         to_return.push(new)
     }
 
     to_return.sort_by(|a, b| a.number.cmp(&b.number));
-    to_return
+    Ok(to_return)
 }
 
 /// Get a vector of speeds reported from each cpu from list_cpus
-pub fn list_cpu_speeds() -> Vec<i32> {
-    list_cpus().into_iter().map(|x| x.cur_freq).collect()
+pub fn list_cpu_speeds() -> Result<Vec<i32>, Error> {
+    Ok(list_cpus()?.into_iter().map(|x| x.cur_freq).collect())
 }
 
 /// Get a vector of temperatures reported from each cpu from list_cpus
-pub fn list_cpu_temp() -> Vec<i32> {
-    list_cpus().into_iter().map(|x| x.cur_temp).collect()
+pub fn list_cpu_temp() -> Result<Vec<i32>, Error> {
+    Ok(list_cpus()?.into_iter().map(|x| x.cur_temp).collect())
 }
 
 /// Get a vector of the governors that the cpus from list_cpus
-pub fn list_cpu_governors() -> Vec<String> {
-    list_cpus().into_iter().map(|x| x.gov).collect()
+pub fn list_cpu_governors() -> Result<Vec<String>, Error> {
+    Ok(list_cpus()?.into_iter().map(|x| x.gov).collect())
 }
 
 pub fn read_int(path: &str) -> Result<i32, Error> {

--- a/src/system.rs
+++ b/src/system.rs
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn check_cpu_freq_acs_test() {
-        assert!(check_cpu_freq(&list_cpus()) > 0.0);
+        assert!(check_cpu_freq(&list_cpus().unwrap()) > 0.0);
     }
 
     #[test]


### PR DESCRIPTION
`list_cpus()` could throw an error if there is an IO error when fetching non-essential information about the CPU. This PR tries to handle those errors and work around them whenever possible so auto clock speed isn't rendered useless.


- Modify `list_cpus()` to return a result and adjust the functions which depend on them to return result.
- Add updated error handling for use of `list_cpus()`
